### PR TITLE
fix: remove artifacts from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ FROM node:alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
-COPY /artifacts ./artifacts 
 RUN npm run build && npm install --production --ignore-scripts --prefer-offline
 
 # Production image, copy all the files and run next


### PR DESCRIPTION
This was a hangover from removing Hardhat. We no longer use the artifacts generated from our Hardhat contracts. 