### PR TITLE
fix: env vars for ecs

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tokey
+spec:
+  selector:
+    matchLabels:
+      app: tokey
+    replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: tokey
+    spec:
+      containers:
+      - name: tokey
+        image: <Image>
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 3000

--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,10 @@ const nextConfig = {
 	},
 	env: {
 		PASSWORD_PROTECT: true,
-		MYVAR: process.env.MY_VAR,
+		NEXT_PUBLIC_ALCHEMY_KEY_POLYGON_MUMBAI:
+			process.env.NEXT_PUBLIC_ALCHEMY_KEY_POLYGON_MUMBAI,
+		NEXT_PUBLIC_TOKEY_MKT_ADDRESS_MUMBAI:
+			process.env.NEXT_PUBLIC_TOKEY_MKT_ADDRESS_MUMBAI,
 	},
 	webpack(config) {
 		config.module.rules.push({

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,10 @@
-import '../styles/globals.css';
-
+import { withPasswordProtect } from '@storyofams/next-password-protect';
+import { ChainId, ThirdwebProvider } from '@thirdweb-dev/react';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
-
-import { ChainId, ThirdwebProvider } from '@thirdweb-dev/react';
-
-import Header from '../components/Header/Header';
 import Footer from '../components/Footer/Footer';
-
-import { withPasswordProtect } from '@storyofams/next-password-protect';
+import Header from '../components/Header/Header';
+import '../styles/globals.css';
 
 function App({ Component, pageProps }: AppProps) {
 	return (

--- a/pages/create.jsx
+++ b/pages/create.jsx
@@ -23,7 +23,7 @@ const Create = () => {
 	const [listingPrice, setListingPrice] = useState(0);
 	const router = useRouter();
 
-	const apiKey = NEXT_PUBLIC_ALCHEMY_KEY_POLYGON_MUMBAI;
+	const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY_POLYGON_MUMBAI;
 	const provider = useMemo(() => {
 		return new AlchemyProvider('maticmum', apiKey);
 	}, [apiKey]);


### PR DESCRIPTION
Env vars aren't being read by the app running in ECS despite being in the container's task definition. 

This is probably because they're not directly referenced in `next.config.js`.

We also have the beginnings of the Kubernetes manifests for the app in this update.  