### PR TITLE
fix: removing creds from secretsClient in prod

### DIFF
--- a/lib/secretsClient.ts
+++ b/lib/secretsClient.ts
@@ -1,18 +1,18 @@
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 
 let credentials;
+export let secretsClient: SecretsManagerClient;
 
-//Uses creds from env.local in staging env
+//Uses creds from env.local in Staging, no creds for Production
 if (process.env.ENVIRONMENT == 'staging') {
 	credentials = {
 		accessKeyId: process.env.STAGING_AWS_ACCESS_KEY_ID as string,
 		secretAccessKey: process.env.STAGING_AWS_SECRET_ACCESS_KEY as string,
 	};
+	secretsClient = new SecretsManagerClient({
+		region: process.env.AWS_REGION,
+		credentials: credentials,
+	});
 } else {
-	credentials = undefined;
+	secretsClient = new SecretsManagerClient({ region: process.env.AWS_REGION });
 }
-
-export const secretsClient = new SecretsManagerClient({
-	region: process.env.AWS_REGION,
-	credentials: credentials,
-});

--- a/pages/secrets.tsx
+++ b/pages/secrets.tsx
@@ -5,6 +5,8 @@ import { secretsClient } from '../lib/secretsClient';
 const Secrets = () => {
 	const [secret, setSecret] = useState('');
 
+	console.log('this is what we are getting from secretsClient:', secretsClient);
+
 	useEffect(() => {
 		async function getSecret() {
 			const params = {


### PR DESCRIPTION
In the previous iteration we were passing in empty credentials in production envs, which is obviously not optimal. 